### PR TITLE
feat: 結果の出力方法 & URL分類の処理の順番の修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,14 +73,14 @@ export const main = () => {
         return { response, keyword, keywordUrls };
     });
 
-    const searchPerformances = searchConsoleResponses.map(({ response, keywordUrls }) => {
+    const responsesGroupedByPageAttribute = searchConsoleResponses.map(({ response, keywordUrls }) => {
         const urls = keywordUrls.map((keywordUrl) => {
             return keywordUrl.url;
         });
-        return formatData(response, urls);
+        return getResponseGroupedByPageAttribute(response, urls);
     });
 
-    writeInSpreadsheet(searchPerformances, resultSheet);
+    writeInSpreadsheet(responsesGroupedByPageAttribute, resultSheet);
 };
 
 const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { startDate: Date; endDate: Date } => {
@@ -151,7 +151,7 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
     return response;
 };
 
-const formatData = (
+const getResponseGroupedByPageAttribute = (
     response: SearchConsoleResponse,
     urls: string[]
 ): {
@@ -182,7 +182,7 @@ const formatData = (
 };
 
 const writeInSpreadsheet = (
-    searchPerformances: {
+    responsesGroupedByPageAttribute: {
         withAnchor: SearchPerformanceGroupedByQueryAndPage;
         matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
         notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
@@ -191,7 +191,7 @@ const writeInSpreadsheet = (
 ) => {
     const header = [["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"]];
 
-    const results = searchPerformances.flatMap((data) => {
+    const results = responsesGroupedByPageAttribute.flatMap((data) => {
         const resultWithAnchor = data.withAnchor.map((row) => [
             row["query"],
             row["page"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,7 +162,7 @@ const getResponseGroupedByPageAttribute = (
     if (response["rows"] === undefined || response["rows"].length === 0) {
         return {};
     }
-    const searchPerformanceGroupedByQueryAndPage = response["rows"].map(({ keys, ...rest }) => {
+    const searchPerformances: SearchPerformanceGroupedByQueryAndPage[] = response["rows"].map(({ keys, ...rest }) => {
         return {
             query: keys[0],
             page: keys[1],
@@ -174,10 +174,8 @@ const getResponseGroupedByPageAttribute = (
      *
      * 参考: https://github.com/siiibo/ownedmedia-search-analysis/pull/4#discussion_r1080962946
      */
-    const withAnchor = searchPerformanceGroupedByQueryAndPage.filter(
-        (row) => row["page"].includes("#") && row["clicks"] >= 1
-    );
-    const withoutAnchor = searchPerformanceGroupedByQueryAndPage.filter((row) => !row["page"].includes("#"));
+    const withAnchor = searchPerformances.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
+    const withoutAnchor = searchPerformances.filter((row) => !row["page"].includes("#"));
     const matchedWithoutAnchor = withoutAnchor.filter((row) => urls.includes(row["page"]));
     const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !urls.includes(row["page"]) && row["clicks"] >= 1);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -225,7 +225,7 @@ const writeInSpreadsheet = (
             row["ctr"],
         ]);
 
-        return resultMatchedWithoutAnchor.concat(resultNotMatchedWithoutAnchor).concat(resultWithAnchor);
+        return [...resultMatchedWithoutAnchor, ...resultNotMatchedWithoutAnchor, ...resultWithAnchor];
     });
 
     const resultsRowNum = results.length;

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,7 +144,7 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
     return responseData;
 };
 
-const formatData = (responseData: SearchConsoleResponse, urls: string[] | undefined): (string | number)[][] => {
+const formatData = (responseData: SearchConsoleResponse, urls: string[]): (string | number)[][] => {
     const withAnchor = responseData["rows"].filter((row) => row["keys"][1].match("#") && row["clicks"] >= 1);
     const withoutAnchor = responseData["rows"].filter((row) => !row["keys"][1].match("#"));
     const matchedWithoutAnchor = withoutAnchor.filter((row) => urls?.includes(row["keys"][1]));

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,15 +145,20 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
 };
 
 const formatData = (responseData: SearchConsoleResponse, urls: string[]): (string | number)[][] => {
-    const withAnchor = responseData["rows"].filter((row) => row["keys"][1].match("#") && row["clicks"] >= 1);
-    const withoutAnchor = responseData["rows"].filter((row) => !row["keys"][1].match("#"));
-    const matchedWithoutAnchor = withoutAnchor.filter((row) => urls?.includes(row["keys"][1]));
-    const notMatchedWithoutAnchor = withoutAnchor.filter(
-        (row) => !urls?.includes(row["keys"][1]) && row["clicks"] >= 1
-    );
+    const results = responseData["rows"].map(({ keys, ...rest }) => {
+        return {
+            query: keys[0],
+            page: keys[1],
+            ...rest,
+        };
+    });
+    const withAnchor = results.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
+    const withoutAnchor = results.filter((row) => !row["page"].includes("#"));
+    const matchedWithoutAnchor = withoutAnchor.filter((row) => urls?.includes(row["page"]));
+    const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !urls?.includes(row["page"]) && row["clicks"] >= 1);
     const resultWithAnchor = withAnchor.map((row) => [
-        row["keys"][0],
-        row["keys"][1],
+        row["query"],
+        row["page"],
         "アンカー付き",
         row["clicks"],
         row["impressions"],
@@ -162,8 +167,8 @@ const formatData = (responseData: SearchConsoleResponse, urls: string[]): (strin
     ]);
 
     const resultMatchedWithoutAnchor = matchedWithoutAnchor.map((row) => [
-        row["keys"][0],
-        row["keys"][1],
+        row["query"],
+        row["page"],
         "完全一致",
         row["clicks"],
         row["impressions"],
@@ -172,8 +177,8 @@ const formatData = (responseData: SearchConsoleResponse, urls: string[]): (strin
     ]);
 
     const resultNotMatchedWithoutAnchor = notMatchedWithoutAnchor.map((row) => [
-        row["keys"][0],
-        row["keys"][1],
+        row["query"],
+        row["page"],
         "不一致",
         row["clicks"],
         row["impressions"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,46 +149,43 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
 };
 
 const formatData = (responseData: SearchConsoleResponse, urls: string[] | undefined): (string | number)[][] => {
-    const result = [];
+    const withAnchor = responseData["rows"].filter((row) => row["keys"][1].match("#") && row["clicks"] >= 1);
+    const withoutAnchor = responseData["rows"].filter((row) => !row["keys"][1].match("#"));
+    const matchedWithoutAnchor = withoutAnchor.filter((row) => urls?.includes(row["keys"][1]));
+    const notMatchedWithoutAnchor = withoutAnchor.filter(
+        (row) => !urls?.includes(row["keys"][1]) && row["clicks"] >= 1
+    );
+    const resultWithAnchor = withAnchor.map((row) => [
+        row["keys"][0],
+        row["keys"][1],
+        "アンカー付き",
+        row["clicks"],
+        row["impressions"],
+        row["position"],
+        row["ctr"],
+    ]);
 
-    for (let i = 0; i < responseData["rows"].length; i++) {
-        // URLが対策URLと一致するなら
-        if (urls?.includes(responseData["rows"][i]["keys"][1])) {
-            result.push([
-                responseData["rows"][i]["keys"][0],
-                responseData["rows"][i]["keys"][1],
-                "完全一致",
-                responseData["rows"][i]["clicks"],
-                responseData["rows"][i]["impressions"],
-                responseData["rows"][i]["position"],
-                responseData["rows"][i]["ctr"],
-            ]);
-        }
-        // 対策URLと一致しないかつ枝付きじゃないかつクリック数が1以上
-        else if (!responseData["rows"][i]["keys"][1].match("#") && responseData["rows"][i]["clicks"] >= 1) {
-            result.push([
-                responseData["rows"][i]["keys"][0],
-                responseData["rows"][i]["keys"][1],
-                "不一致",
-                responseData["rows"][i]["clicks"],
-                responseData["rows"][i]["impressions"],
-                responseData["rows"][i]["position"],
-                responseData["rows"][i]["ctr"],
-            ]);
-        }
-        // URLが枝付きかつクリックが1以上なら
-        else if (responseData["rows"][i]["clicks"] >= 1) {
-            result.push([
-                responseData["rows"][i]["keys"][0],
-                responseData["rows"][i]["keys"][1],
-                "アンカー付き",
-                responseData["rows"][i]["clicks"],
-                responseData["rows"][i]["impressions"],
-                responseData["rows"][i]["position"],
-                responseData["rows"][i]["ctr"],
-            ]);
-        }
-    }
+    const resultMatchedWithoutAnchor = matchedWithoutAnchor.map((row) => [
+        row["keys"][0],
+        row["keys"][1],
+        "完全一致",
+        row["clicks"],
+        row["impressions"],
+        row["position"],
+        row["ctr"],
+    ]);
+
+    const resultNotMatchedWithoutAnchor = notMatchedWithoutAnchor.map((row) => [
+        row["keys"][0],
+        row["keys"][1],
+        "不一致",
+        row["clicks"],
+        row["impressions"],
+        row["position"],
+        row["ctr"],
+    ]);
+
+    const result = resultMatchedWithoutAnchor.concat(resultNotMatchedWithoutAnchor).concat(resultWithAnchor);
     return result;
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,10 @@ export const main = () => {
 
     const keywordUrl = getUrlsGroupedByKeyword(keywordUrlSheet);
 
-    const resultSheet = spreadsheet.insertSheet(3);
+    const resultSheet = spreadsheet.insertSheet(
+        `${format(startDate, "yyyy-MM-dd")}~${format(endDate, "MM-dd")}-掲載順位結果`,
+        3
+    );
 
     setHeader(resultSheet);
 
@@ -73,7 +76,6 @@ export const main = () => {
             console.log("該当するデータがありませんでした。");
         }
     }
-    resultSheet.setName(format(startDate, "yyyy-MM-dd") + "~" + format(endDate, "MM-dd") + "-" + "掲載順位結果");
 };
 const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { startDate: Date; endDate: Date } => {
     const startDate = periodSheet.getRange("B4").getValue();

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ type SearchConsoleResponse = {
     }[];
 };
 
-type FormattedResponse = {
+type SearchPerformanceGroupedByQueryAndPage = {
     clicks: number;
     ctr: number;
     impressions: number;
@@ -160,11 +160,11 @@ const formatData = (
     response: SearchConsoleResponse,
     urls: string[]
 ): {
-    withAnchor: FormattedResponse;
-    matchedWithoutAnchor: FormattedResponse;
-    notMatchedWithoutAnchor: FormattedResponse;
+    withAnchor: SearchPerformanceGroupedByQueryAndPage;
+    matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
+    notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
 } => {
-    const formattedResponse = response["rows"].map(({ keys, ...rest }) => {
+    const searchPerformanceGroupedByQueryAndPage = response["rows"].map(({ keys, ...rest }) => {
         return {
             query: keys[0],
             page: keys[1],
@@ -176,8 +176,10 @@ const formatData = (
      *
      * 参考: https://github.com/siiibo/ownedmedia-search-analysis/pull/4#discussion_r1080962946
      */
-    const withAnchor = formattedResponse.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
-    const withoutAnchor = formattedResponse.filter((row) => !row["page"].includes("#"));
+    const withAnchor = searchPerformanceGroupedByQueryAndPage.filter(
+        (row) => row["page"].includes("#") && row["clicks"] >= 1
+    );
+    const withoutAnchor = searchPerformanceGroupedByQueryAndPage.filter((row) => !row["page"].includes("#"));
     const matchedWithoutAnchor = withoutAnchor.filter((row) => urls.includes(row["page"]));
     const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !urls.includes(row["page"]) && row["clicks"] >= 1);
 
@@ -186,9 +188,9 @@ const formatData = (
 
 const writeInSpreadsheet = (
     formattedDataList: {
-        withAnchor: FormattedResponse;
-        matchedWithoutAnchor: FormattedResponse;
-        notMatchedWithoutAnchor: FormattedResponse;
+        withAnchor: SearchPerformanceGroupedByQueryAndPage;
+        matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
+        notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
     }[],
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ type SearchConsoleResponse = {
     }[];
 };
 
-type FormattedData = {
+type FormattedResponse = {
     clicks: number;
     ctr: number;
     impressions: number;
@@ -161,8 +161,12 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
 const formatData = (
     response: SearchConsoleResponse,
     urls: string[]
-): { withAnchor: FormattedData; matchedWithoutAnchor: FormattedData; notMatchedWithoutAnchor: FormattedData } => {
-    const results = response["rows"].map(({ keys, ...rest }) => {
+): {
+    withAnchor: FormattedResponse;
+    matchedWithoutAnchor: FormattedResponse;
+    notMatchedWithoutAnchor: FormattedResponse;
+} => {
+    const formattedResponse = response["rows"].map(({ keys, ...rest }) => {
         return {
             query: keys[0],
             page: keys[1],
@@ -174,8 +178,8 @@ const formatData = (
      *
      * 参考: https://github.com/siiibo/ownedmedia-search-analysis/pull/4#discussion_r1080962946
      */
-    const withAnchor = results.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
-    const withoutAnchor = results.filter((row) => !row["page"].includes("#"));
+    const withAnchor = formattedResponse.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
+    const withoutAnchor = formattedResponse.filter((row) => !row["page"].includes("#"));
     const matchedWithoutAnchor = withoutAnchor.filter((row) => urls.includes(row["page"]));
     const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !urls.includes(row["page"]) && row["clicks"] >= 1);
 
@@ -183,7 +187,11 @@ const formatData = (
 };
 
 const writeInSpreadsheet = (
-    data: { withAnchor: FormattedData; matchedWithoutAnchor: FormattedData; notMatchedWithoutAnchor: FormattedData },
+    data: {
+        withAnchor: FormattedResponse;
+        matchedWithoutAnchor: FormattedResponse;
+        notMatchedWithoutAnchor: FormattedResponse;
+    },
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {
     const resultWithAnchor = data.withAnchor.map((row) => [

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,6 +157,11 @@ const formatData = (response: SearchConsoleResponse, urls: string[]): (string | 
             ...rest,
         };
     });
+    /**
+     * アンカー付き, 不一致はさらに「クリック数1以上のみ」で絞り込みを行う. 完全一致は行わない.
+     *
+     * 参考: https://github.com/siiibo/ownedmedia-search-analysis/pull/4#discussion_r1080962946
+     */
     const withAnchor = results.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
     const withoutAnchor = results.filter((row) => !row["page"].includes("#"));
     const matchedWithoutAnchor = withoutAnchor.filter((row) => urls?.includes(row["page"]));

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,15 +62,15 @@ export const main = () => {
     );
 
     const searchConsoleResponses = keywordUrlEntries.map(([keyword, keywordUrls]) => {
-        const searchConsoleResponse = getDataFromSearchConsole(keyword, startDate, endDate);
-        return { searchConsoleResponse, keyword, keywordUrls };
+        const response = getDataFromSearchConsole(keyword, startDate, endDate);
+        return { response, keyword, keywordUrls };
     });
 
-    const formattedDataList = searchConsoleResponses.map(({ searchConsoleResponse, keywordUrls }) => {
+    const formattedDataList = searchConsoleResponses.map(({ response, keywordUrls }) => {
         const urls = keywordUrls.map((keywordUrl) => {
             return keywordUrl.url;
         });
-        return formatData(searchConsoleResponse, urls);
+        return formatData(response, urls);
     });
 
     formattedDataList.forEach((data) => writeInSpreadsheet(data, resultSheet));
@@ -144,13 +144,13 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
         contentType: "application/json",
     };
 
-    const response = UrlFetchApp.fetch(apiUrl, options);
-    const responseData: SearchConsoleResponse = JSON.parse(response.getContentText());
-    return responseData;
+    const httpResponse = UrlFetchApp.fetch(apiUrl, options);
+    const response: SearchConsoleResponse = JSON.parse(httpResponse.getContentText());
+    return response;
 };
 
-const formatData = (responseData: SearchConsoleResponse, urls: string[]): (string | number)[][] => {
-    const results = responseData["rows"].map(({ keys, ...rest }) => {
+const formatData = (response: SearchConsoleResponse, urls: string[]): (string | number)[][] => {
+    const results = response["rows"].map(({ keys, ...rest }) => {
         return {
             query: keys[0],
             page: keys[1],

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,8 +64,8 @@ export const main = () => {
             const urls = values.map((value) => {
                 return value.url;
             });
-            const response = getDataFromSearchConsole(keyword, startDate, endDate);
-            const result: (string | number)[][] = formatData(response, urls);
+            const responseData = getDataFromSearchConsole(keyword, startDate, endDate);
+            const result: (string | number)[][] = formatData(responseData, urls);
             results.push(result);
         });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,8 +64,6 @@ export const main = () => {
         3
     );
 
-    setHeader(resultSheet);
-
     const keywordUrlEntries = Object.entries(keywordUrl).filter(
         (kv): kv is [string, KeywordUrl[]] => kv[1] != undefined
     );
@@ -194,6 +192,8 @@ const writeInSpreadsheet = (
     }[],
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {
+    setHeader(resultSheet);
+
     const results = formattedDataList.flatMap((data) => {
         const resultWithAnchor = data.withAnchor.map((row) => [
             row["query"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,10 +68,18 @@ export const main = () => {
         (kv): kv is [string, KeywordUrl[]] => kv[1] != undefined
     );
 
-    const searchConsoleResponses = keywordUrlEntries.map(([keyword, keywordUrls]) => {
-        const response = getDataFromSearchConsole(keyword, startDate, endDate);
-        return { response, keyword, keywordUrls };
-    });
+    const searchConsoleResponses = keywordUrlEntries
+        .map(([keyword, keywordUrls]) => {
+            const response = getDataFromSearchConsole(keyword, startDate, endDate);
+            return { response, keyword, keywordUrls };
+        })
+        .filter(
+            (searchConsoleResponse) =>
+                !(
+                    typeof searchConsoleResponse.response["rows"] === "undefined" ||
+                    searchConsoleResponse.response["rows"].length === 0
+                )
+        );
 
     const responsesGroupedByPageAttribute = searchConsoleResponses.map(({ response, keywordUrls }) => {
         const urls = keywordUrls.map((keywordUrl) => {
@@ -226,7 +234,7 @@ const writeInSpreadsheet = (
     });
 
     if (contents.length >= 1) {
-        resultSheet.getRange(1, 1, contents.length + 1, header.length).setValues([...header, ...contents]);
+        resultSheet.getRange(1, 1, contents.length + 1, header[0].length).setValues([...header, ...contents]);
         resultSheet.getRange(2, 7, contents.length, 1).setNumberFormat("0.00%");
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,14 +73,14 @@ export const main = () => {
         return { response, keyword, keywordUrls };
     });
 
-    const formattedDataList = searchConsoleResponses.map(({ response, keywordUrls }) => {
+    const searchPerformances = searchConsoleResponses.map(({ response, keywordUrls }) => {
         const urls = keywordUrls.map((keywordUrl) => {
             return keywordUrl.url;
         });
         return formatData(response, urls);
     });
 
-    writeInSpreadsheet(formattedDataList, resultSheet);
+    writeInSpreadsheet(searchPerformances, resultSheet);
 };
 
 const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { startDate: Date; endDate: Date } => {
@@ -182,7 +182,7 @@ const formatData = (
 };
 
 const writeInSpreadsheet = (
-    formattedDataList: {
+    searchPerformances: {
         withAnchor: SearchPerformanceGroupedByQueryAndPage;
         matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
         notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
@@ -191,7 +191,7 @@ const writeInSpreadsheet = (
 ) => {
     const header = [["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"]];
 
-    const results = formattedDataList.flatMap((data) => {
+    const results = searchPerformances.flatMap((data) => {
         const resultWithAnchor = data.withAnchor.map((row) => [
             row["query"],
             row["page"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -191,7 +191,7 @@ const writeInSpreadsheet = (
 ) => {
     const header = [["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"]];
 
-    const results = responsesGroupedByPageAttribute.flatMap((data) => {
+    const contents = responsesGroupedByPageAttribute.flatMap((data) => {
         const resultWithAnchor = data.withAnchor.map((row) => [
             row["query"],
             row["page"],
@@ -225,11 +225,8 @@ const writeInSpreadsheet = (
         return [...resultMatchedWithoutAnchor, ...resultNotMatchedWithoutAnchor, ...resultWithAnchor];
     });
 
-    const resultsRowNum = results.length;
-    const resultsColumnNum = results[0].length;
-
-    if (resultsRowNum >= 1) {
-        resultSheet.getRange(1, 1, resultsRowNum, resultsColumnNum).setValues([...header, ...results]);
-        resultSheet.getRange(2, 7, resultsRowNum, 1).setNumberFormat("0.00%");
+    if (contents.length >= 1) {
+        resultSheet.getRange(1, 1, contents.length + 1, header.length).setValues([...header, ...contents]);
+        resultSheet.getRange(2, 7, contents.length, 1).setNumberFormat("0.00%");
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,25 +57,19 @@ export const main = () => {
 
     setHeader(resultSheet);
 
-    for (const [keyword, values] of Object.entries(keywordUrl)) {
-        if (values == undefined) {
-            continue;
-        }
-        const urls = values.map((value) => {
-            return value.url;
+    const results: (string | number)[][][] = [];
+    Object.entries(keywordUrl)
+        .filter((kv): kv is [string, KeywordUrl[]] => kv[1] != undefined)
+        .forEach(([keyword, values]) => {
+            const urls = values.map((value) => {
+                return value.url;
+            });
+            const response = getDataFromSearchConsole(keyword, startDate, endDate);
+            const result: (string | number)[][] = formatData(response, urls);
+            results.push(result);
         });
-        const responseData = getDataFromSearchConsole(keyword, startDate, endDate);
 
-        if (!(typeof responseData["rows"] === "undefined" || responseData["rows"].length === 0)) {
-            if (keywordUrl[keyword] != undefined) {
-                const result = formatData(responseData, urls);
-
-                writeInSpreadsheet(result, resultSheet);
-            }
-        } else {
-            console.log("該当するデータがありませんでした。");
-        }
-    }
+    results.forEach((result) => writeInSpreadsheet(result, resultSheet));
 };
 const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { startDate: Date; endDate: Date } => {
     const startDate = periodSheet.getRange("B4").getValue();

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ type SearchConsoleResponse = {
     }[];
 };
 
-type FormatData = {
+type FormattedData = {
     clicks: number;
     ctr: number;
     impressions: number;
@@ -161,7 +161,7 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
 const formatData = (
     response: SearchConsoleResponse,
     urls: string[]
-): { withAnchor: FormatData; matchedWithoutAnchor: FormatData; notMatchedWithoutAnchor: FormatData } => {
+): { withAnchor: FormattedData; matchedWithoutAnchor: FormattedData; notMatchedWithoutAnchor: FormattedData } => {
     const results = response["rows"].map(({ keys, ...rest }) => {
         return {
             query: keys[0],
@@ -183,7 +183,7 @@ const formatData = (
 };
 
 const writeInSpreadsheet = (
-    data: { withAnchor: FormatData; matchedWithoutAnchor: FormatData; notMatchedWithoutAnchor: FormatData },
+    data: { withAnchor: FormattedData; matchedWithoutAnchor: FormattedData; notMatchedWithoutAnchor: FormattedData },
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {
     const resultWithAnchor = data.withAnchor.map((row) => [

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,20 +57,25 @@ export const main = () => {
 
     setHeader(resultSheet);
 
-    const results: (string | number)[][][] = [];
-    Object.entries(keywordUrl)
-        .filter((kv): kv is [string, KeywordUrl[]] => kv[1] != undefined)
-        .forEach(([keyword, values]) => {
-            const urls = values.map((value) => {
-                return value.url;
-            });
-            const responseData = getDataFromSearchConsole(keyword, startDate, endDate);
-            const result: (string | number)[][] = formatData(responseData, urls);
-            results.push(result);
-        });
+    const keywordUrlEntries = Object.entries(keywordUrl).filter(
+        (kv): kv is [string, KeywordUrl[]] => kv[1] != undefined
+    );
 
-    results.forEach((result) => writeInSpreadsheet(result, resultSheet));
+    const searchConsoleResponses = keywordUrlEntries.map(([keyword, keywordUrls]) => {
+        const searchConsoleResponse = getDataFromSearchConsole(keyword, startDate, endDate);
+        return { searchConsoleResponse, keyword, keywordUrls };
+    });
+
+    const formattedDataList = searchConsoleResponses.map(({ searchConsoleResponse, keywordUrls }) => {
+        const urls = keywordUrls.map((keywordUrl) => {
+            return keywordUrl.url;
+        });
+        return formatData(searchConsoleResponse, urls);
+    });
+
+    formattedDataList.forEach((data) => writeInSpreadsheet(data, resultSheet));
 };
+
 const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { startDate: Date; endDate: Date } => {
     const startDate = periodSheet.getRange("B4").getValue();
     const endDate = endOfDay(periodSheet.getRange("C4").getValue());

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ export const main = () => {
         return formatData(response, urls);
     });
 
-    formattedDataList.forEach((data) => writeInSpreadsheet(data, resultSheet));
+    writeInSpreadsheet(formattedDataList, resultSheet);
 };
 
 const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { startDate: Date; endDate: Date } => {
@@ -187,44 +187,46 @@ const formatData = (
 };
 
 const writeInSpreadsheet = (
-    data: {
+    formattedDataList: {
         withAnchor: FormattedResponse;
         matchedWithoutAnchor: FormattedResponse;
         notMatchedWithoutAnchor: FormattedResponse;
-    },
+    }[],
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {
-    const resultWithAnchor = data.withAnchor.map((row) => [
-        row["query"],
-        row["page"],
-        "アンカー付き",
-        row["clicks"],
-        row["impressions"],
-        row["position"],
-        row["ctr"],
-    ]);
+    const results = formattedDataList.flatMap((data) => {
+        const resultWithAnchor = data.withAnchor.map((row) => [
+            row["query"],
+            row["page"],
+            "アンカー付き",
+            row["clicks"],
+            row["impressions"],
+            row["position"],
+            row["ctr"],
+        ]);
 
-    const resultMatchedWithoutAnchor = data.matchedWithoutAnchor.map((row) => [
-        row["query"],
-        row["page"],
-        "完全一致",
-        row["clicks"],
-        row["impressions"],
-        row["position"],
-        row["ctr"],
-    ]);
+        const resultMatchedWithoutAnchor = data.matchedWithoutAnchor.map((row) => [
+            row["query"],
+            row["page"],
+            "完全一致",
+            row["clicks"],
+            row["impressions"],
+            row["position"],
+            row["ctr"],
+        ]);
 
-    const resultNotMatchedWithoutAnchor = data.notMatchedWithoutAnchor.map((row) => [
-        row["query"],
-        row["page"],
-        "不一致",
-        row["clicks"],
-        row["impressions"],
-        row["position"],
-        row["ctr"],
-    ]);
+        const resultNotMatchedWithoutAnchor = data.notMatchedWithoutAnchor.map((row) => [
+            row["query"],
+            row["page"],
+            "不一致",
+            row["clicks"],
+            row["impressions"],
+            row["position"],
+            row["ctr"],
+        ]);
 
-    const results = resultMatchedWithoutAnchor.concat(resultNotMatchedWithoutAnchor).concat(resultWithAnchor);
+        return resultMatchedWithoutAnchor.concat(resultNotMatchedWithoutAnchor).concat(resultWithAnchor);
+    });
 
     const resultsRowNum = results.length;
     const resultsColumnNum = results[0].length;

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,8 +164,8 @@ const formatData = (response: SearchConsoleResponse, urls: string[]): (string | 
      */
     const withAnchor = results.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
     const withoutAnchor = results.filter((row) => !row["page"].includes("#"));
-    const matchedWithoutAnchor = withoutAnchor.filter((row) => urls?.includes(row["page"]));
-    const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !urls?.includes(row["page"]) && row["clicks"] >= 1);
+    const matchedWithoutAnchor = withoutAnchor.filter((row) => urls.includes(row["page"]));
+    const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !urls.includes(row["page"]) && row["clicks"] >= 1);
     const resultWithAnchor = withAnchor.map((row) => [
         row["query"],
         row["page"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,17 @@ type SearchConsoleResponse = {
     }[];
 };
 
+type SearchConsoleResponse2 = {
+    responseAggregationType: string;
+    rows: {
+        clicks: number;
+        ctr: number;
+        impressions: number;
+        keys: string[];
+        position: number;
+    }[];
+};
+
 type SearchPerformanceGroupedByQueryAndPage = {
     clicks: number;
     ctr: number;
@@ -74,7 +85,13 @@ export const main = () => {
             return { response, keyword, keywordUrls };
         })
         .filter(
-            (searchConsoleResponse) =>
+            (
+                searchConsoleResponse
+            ): searchConsoleResponse is {
+                response: SearchConsoleResponse2;
+                keyword: string;
+                keywordUrls: KeywordUrl[];
+            } =>
                 !(
                     typeof searchConsoleResponse.response["rows"] === "undefined" ||
                     searchConsoleResponse.response["rows"].length === 0
@@ -160,7 +177,7 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
 };
 
 const getResponseGroupedByPageAttribute = (
-    response: SearchConsoleResponse,
+    response: SearchConsoleResponse2,
     urls: string[]
 ): {
     withAnchor: SearchPerformanceGroupedByQueryAndPage;

--- a/src/main.ts
+++ b/src/main.ts
@@ -224,12 +224,14 @@ const writeInSpreadsheet = (
         row["ctr"],
     ]);
 
-    const result = resultMatchedWithoutAnchor.concat(resultNotMatchedWithoutAnchor).concat(resultWithAnchor);
+    const results = resultMatchedWithoutAnchor.concat(resultNotMatchedWithoutAnchor).concat(resultWithAnchor);
 
-    if (result.length >= 1) {
-        const resultColumnBVals = resultSheet.getRange("A:A").getValues();
-        const resultLastRow = resultColumnBVals.filter(String).length;
-        resultSheet.getRange(resultLastRow + 1, 1, result.length, result[0].length).setValues(result);
-        resultSheet.getRange(resultLastRow + 1, 7, result.length).setNumberFormat("0.00%");
+    const resultsRowNum = results.length;
+    const resultsColumnNum = results[0].length;
+
+    if (resultsRowNum >= 1) {
+        const lastRow = resultSheet.getLastRow();
+        resultSheet.getRange(lastRow + 1, 1, resultsRowNum, resultsColumnNum).setValues(results);
+        resultSheet.getRange(lastRow + 1, 7, resultsRowNum, 1).setNumberFormat("0.00%");
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,13 +155,11 @@ const getResponseGroupedByPageAttribute = (
     response: SearchConsoleResponse,
     urls: string[]
 ): {
-    withAnchor?: SearchPerformanceGroupedByQueryAndPage[];
-    matchedWithoutAnchor?: SearchPerformanceGroupedByQueryAndPage[];
-    notMatchedWithoutAnchor?: SearchPerformanceGroupedByQueryAndPage[];
+    withAnchor: SearchPerformanceGroupedByQueryAndPage[];
+    matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
+    notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
 } => {
-    if (response["rows"] === undefined || response["rows"].length === 0) {
-        return {};
-    }
+    if (!response["rows"]) return { withAnchor: [], matchedWithoutAnchor: [], notMatchedWithoutAnchor: [] };
     const searchPerformances: SearchPerformanceGroupedByQueryAndPage[] = response["rows"].map(({ keys, ...rest }) => {
         return {
             query: keys[0],
@@ -184,21 +182,15 @@ const getResponseGroupedByPageAttribute = (
 
 const writeInSpreadsheet = (
     responsesGroupedByPageAttribute: {
-        withAnchor?: SearchPerformanceGroupedByQueryAndPage[];
-        matchedWithoutAnchor?: SearchPerformanceGroupedByQueryAndPage[];
-        notMatchedWithoutAnchor?: SearchPerformanceGroupedByQueryAndPage[];
+        withAnchor: SearchPerformanceGroupedByQueryAndPage[];
+        matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
+        notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
     }[],
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {
     const header = ["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"];
 
     const contents = responsesGroupedByPageAttribute.flatMap((data) => {
-        if (
-            data.withAnchor === undefined ||
-            data.matchedWithoutAnchor === undefined ||
-            data.notMatchedWithoutAnchor === undefined
-        )
-            return;
         const resultWithAnchor = data.withAnchor.map((row) => [
             row["query"],
             row["page"],
@@ -232,13 +224,8 @@ const writeInSpreadsheet = (
         return [...resultMatchedWithoutAnchor, ...resultNotMatchedWithoutAnchor, ...resultWithAnchor];
     });
 
-    const contentsExcludedUndefined = contents.filter(
-        (content): content is (string | number)[] => content !== undefined
-    );
     if (contents.length >= 1) {
-        resultSheet
-            .getRange(1, 1, contents.length + 1, header.length)
-            .setValues([header, ...contentsExcludedUndefined]);
+        resultSheet.getRange(1, 1, contents.length + 1, header.length).setValues([header, ...contents]);
         resultSheet.getRange(2, 7, contents.length, 1).setNumberFormat("0.00%");
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,15 @@ type KeywordUrl = {
 
 type SearchConsoleResponse = {
     responseAggregationType: string;
-    rows: {
-        clicks: number;
-        ctr: number;
-        impressions: number;
-        keys: string[];
-        position: number;
-    }[];
+    rows:
+        | {
+              clicks: number;
+              ctr: number;
+              impressions: number;
+              keys: string[];
+              position: number;
+          }[]
+        | undefined;
 };
 
 type SearchPerformanceGroupedByQueryAndPage = {
@@ -234,7 +236,7 @@ const writeInSpreadsheet = (
     });
 
     if (contents.length >= 1) {
-        resultSheet.getRange(1, 1, contents.length + 1, header.length).setValues([...[header], ...contents]);
+        resultSheet.getRange(1, 1, contents.length + 1, header.length).setValues([header, ...contents]);
         resultSheet.getRange(2, 7, contents.length, 1).setNumberFormat("0.00%");
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,7 +197,7 @@ const writeInSpreadsheet = (
     }[],
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {
-    const header = [["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"]];
+    const header = ["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"];
 
     const contents = responsesGroupedByPageAttribute.flatMap((data) => {
         const resultWithAnchor = data.withAnchor.map((row) => [
@@ -234,7 +234,7 @@ const writeInSpreadsheet = (
     });
 
     if (contents.length >= 1) {
-        resultSheet.getRange(1, 1, contents.length + 1, header[0].length).setValues([...header, ...contents]);
+        resultSheet.getRange(1, 1, contents.length + 1, header.length).setValues([...[header], ...contents]);
         resultSheet.getRange(2, 7, contents.length, 1).setNumberFormat("0.00%");
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,15 +8,13 @@ type KeywordUrl = {
 
 type SearchConsoleResponse = {
     responseAggregationType: string;
-    rows:
-        | {
-              clicks: number;
-              ctr: number;
-              impressions: number;
-              keys: string[];
-              position: number;
-          }[]
-        | undefined;
+    rows?: {
+        clicks: number;
+        ctr: number;
+        impressions: number;
+        keys: string[];
+        position: number;
+    }[];
 };
 
 type SearchPerformanceGroupedByQueryAndPage = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ type SearchPerformanceGroupedByQueryAndPage = {
     position: number;
     query: string;
     page: string;
-}[];
+};
 
 export const init = () => {
     const spreadsheet = getSpreadsheet();
@@ -180,9 +180,9 @@ const getResponseGroupedByPageAttribute = (
     response: SearchConsoleResponse2,
     urls: string[]
 ): {
-    withAnchor: SearchPerformanceGroupedByQueryAndPage;
-    matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
-    notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
+    withAnchor: SearchPerformanceGroupedByQueryAndPage[];
+    matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
+    notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
 } => {
     const searchPerformanceGroupedByQueryAndPage = response["rows"].map(({ keys, ...rest }) => {
         return {
@@ -208,9 +208,9 @@ const getResponseGroupedByPageAttribute = (
 
 const writeInSpreadsheet = (
     responsesGroupedByPageAttribute: {
-        withAnchor: SearchPerformanceGroupedByQueryAndPage;
-        matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
-        notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage;
+        withAnchor: SearchPerformanceGroupedByQueryAndPage[];
+        matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
+        notMatchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
     }[],
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,11 +89,6 @@ const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { sta
     return { startDate, endDate };
 };
 
-const setHeader = (resultSheet: GoogleAppsScript.Spreadsheet.Sheet) => {
-    const header = [["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"]];
-    resultSheet.getRange(1, 1, 1, header[0].length).setValues(header);
-};
-
 function getUrlsGroupedByKeyword(keywordUrlSheet: GoogleAppsScript.Spreadsheet.Sheet) {
     const [_sheetHeader, ...sheetValues] = keywordUrlSheet.getDataRange().getValues();
     const keywordUrls: KeywordUrl[] = sheetValues.map((row) => {
@@ -194,7 +189,7 @@ const writeInSpreadsheet = (
     }[],
     resultSheet: GoogleAppsScript.Spreadsheet.Sheet
 ) => {
-    setHeader(resultSheet);
+    const header = [["キーワード", "記事URL", "タイプ", "クリック数", "インプレッション", "平均順位", "平均CTR"]];
 
     const results = formattedDataList.flatMap((data) => {
         const resultWithAnchor = data.withAnchor.map((row) => [
@@ -234,8 +229,7 @@ const writeInSpreadsheet = (
     const resultsColumnNum = results[0].length;
 
     if (resultsRowNum >= 1) {
-        const lastRow = resultSheet.getLastRow();
-        resultSheet.getRange(lastRow + 1, 1, resultsRowNum, resultsColumnNum).setValues(results);
-        resultSheet.getRange(lastRow + 1, 7, resultsRowNum, 1).setNumberFormat("0.00%");
+        resultSheet.getRange(1, 1, resultsRowNum, resultsColumnNum).setValues([...header, ...results]);
+        resultSheet.getRange(2, 7, resultsRowNum, 1).setNumberFormat("0.00%");
     }
 };


### PR DESCRIPTION
- 結果をURLのタイプごとの複数表に出力していたが，URLタイプを表す属性を追加することで，一つの表にまとめた. 
[参考](https://trello.com/c/yMfnvC9v/238-%E3%82%AA%E3%82%A6%E3%83%B3%E3%83%89%E3%83%A1%E3%83%87%E3%82%A3%E3%82%A2%E5%90%84%E8%A8%98%E4%BA%8B%E3%81%AE%E8%87%AA%E7%84%B6%E6%A4%9C%E7%B4%A2%E3%81%AE%E6%8E%B2%E8%BC%89%E9%A0%86%E4%BD%8D%E3%82%92%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B#comment-63b78e9ffc28c700d7390b06)
- URLの分類の順番が，対策URLに一致するか → 対策URLに一致しないものの中で，アンカー付きか だったが，アンカー付きか → アンカー付きでないもので，対策URLに一致するか の順に変更した. 
   - [こちら](https://trello.com/c/yMfnvC9v/238-%E3%82%AA%E3%82%A6%E3%83%B3%E3%83%89%E3%83%A1%E3%83%87%E3%82%A3%E3%82%A2%E5%90%84%E8%A8%98%E4%BA%8B%E3%81%AE%E8%87%AA%E7%84%B6%E6%A4%9C%E7%B4%A2%E3%81%AE%E6%8E%B2%E8%BC%89%E9%A0%86%E4%BD%8D%E3%82%92%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B#comment-63bfad7e75d94502c5ff2b2e) のパターン1のようにした. 