### PR TITLE
fix: キーワードのグルーピングをなくす

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,16 +56,14 @@ export const main = () => {
     const keywordUrlSheet = spreadsheet.getSheetByName("キーワードURL指定");
     if (!keywordUrlSheet) throw new Error("SHEET is not defined");
 
-    const keywordUrlEntries = getKeywordUrls(keywordUrlSheet);
+    const keywordUrls = getKeywordUrls(keywordUrlSheet);
 
     const resultSheet = spreadsheet.insertSheet(
         `${format(startDate, "yyyy-MM-dd")}~${format(endDate, "MM-dd")}-掲載順位結果`,
         3
     );
 
-    // const keywordUrlEntries = Object.entries(keywordUrl).filter((kv): kv is [string, string] => kv[1] != undefined);
-
-    const searchConsoleResponses = keywordUrlEntries.map((keywordUrl) => {
+    const searchConsoleResponses = keywordUrls.map((keywordUrl) => {
         const response = getDataFromSearchConsole(keywordUrl.keyword, startDate, endDate);
         return { response, keywordUrl };
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { endOfDay, format } from "date-fns";
-import { group } from "radash";
 
 type KeywordUrl = {
     keyword: string;
@@ -57,27 +56,23 @@ export const main = () => {
     const keywordUrlSheet = spreadsheet.getSheetByName("キーワードURL指定");
     if (!keywordUrlSheet) throw new Error("SHEET is not defined");
 
-    const keywordUrl = getUrlsGroupedByKeyword(keywordUrlSheet);
+    const keywordUrlEntries = getKeywordUrls(keywordUrlSheet);
 
     const resultSheet = spreadsheet.insertSheet(
         `${format(startDate, "yyyy-MM-dd")}~${format(endDate, "MM-dd")}-掲載順位結果`,
         3
     );
 
-    const keywordUrlEntries = Object.entries(keywordUrl).filter(
-        (kv): kv is [string, KeywordUrl[]] => kv[1] != undefined
-    );
+    // const keywordUrlEntries = Object.entries(keywordUrl).filter((kv): kv is [string, string] => kv[1] != undefined);
 
-    const searchConsoleResponses = keywordUrlEntries.map(([keyword, keywordUrls]) => {
-        const response = getDataFromSearchConsole(keyword, startDate, endDate);
-        return { response, keyword, keywordUrls };
+    const searchConsoleResponses = keywordUrlEntries.map((keywordUrl) => {
+        const response = getDataFromSearchConsole(keywordUrl.keyword, startDate, endDate);
+        return { response, keywordUrl };
     });
 
-    const responsesGroupedByPageAttribute = searchConsoleResponses.map(({ response, keywordUrls }) => {
-        const urls = keywordUrls.map((keywordUrl) => {
-            return keywordUrl.url;
-        });
-        return getResponseGroupedByPageAttribute(response, urls);
+    const responsesGroupedByPageAttribute = searchConsoleResponses.map(({ response, keywordUrl }) => {
+        const url = keywordUrl.url;
+        return getResponseGroupedByPageAttribute(response, url);
     });
 
     writeInSpreadsheet(responsesGroupedByPageAttribute, resultSheet);
@@ -89,7 +84,7 @@ const getStartEndDate = (periodSheet: GoogleAppsScript.Spreadsheet.Sheet): { sta
     return { startDate, endDate };
 };
 
-function getUrlsGroupedByKeyword(keywordUrlSheet: GoogleAppsScript.Spreadsheet.Sheet) {
+function getKeywordUrls(keywordUrlSheet: GoogleAppsScript.Spreadsheet.Sheet) {
     const [_sheetHeader, ...sheetValues] = keywordUrlSheet.getDataRange().getValues();
     const keywordUrls: KeywordUrl[] = sheetValues.map((row) => {
         return {
@@ -97,8 +92,7 @@ function getUrlsGroupedByKeyword(keywordUrlSheet: GoogleAppsScript.Spreadsheet.S
             url: row[1],
         };
     });
-    const urlGroupedByKeyword = group(keywordUrls, (keywordUrl) => keywordUrl.keyword);
-    return urlGroupedByKeyword;
+    return keywordUrls;
 }
 
 /**
@@ -153,7 +147,7 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
 
 const getResponseGroupedByPageAttribute = (
     response: SearchConsoleResponse,
-    urls: string[]
+    url: string
 ): {
     withAnchor: SearchPerformanceGroupedByQueryAndPage[];
     matchedWithoutAnchor: SearchPerformanceGroupedByQueryAndPage[];
@@ -174,8 +168,8 @@ const getResponseGroupedByPageAttribute = (
      */
     const withAnchor = searchPerformances.filter((row) => row["page"].includes("#") && row["clicks"] >= 1);
     const withoutAnchor = searchPerformances.filter((row) => !row["page"].includes("#"));
-    const matchedWithoutAnchor = withoutAnchor.filter((row) => urls.includes(row["page"]));
-    const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !urls.includes(row["page"]) && row["clicks"] >= 1);
+    const matchedWithoutAnchor = withoutAnchor.filter((row) => url === row["page"]);
+    const notMatchedWithoutAnchor = withoutAnchor.filter((row) => !(url === row["page"]) && row["clicks"] >= 1);
 
     return { withAnchor, matchedWithoutAnchor, notMatchedWithoutAnchor };
 };


### PR DESCRIPTION
キーワードごとにキーワード，URLをグルーピングしていたが，グルーピングをなくした．

参考Trello: [コメント①](https://trello.com/c/U9CH7xIK/293-%E3%82%AA%E3%82%A6%E3%83%B3%E3%83%89%E3%83%A1%E3%83%87%E3%82%A3%E3%82%A2%E6%A4%9C%E7%B4%A2%E5%88%86%E6%9E%90%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E5%87%BA%E5%8A%9B%E5%BD%A2%E5%BC%8F%E3%82%92%E5%A4%89%E6%9B%B4%E3%81%99%E3%82%8B#comment-63e0b6fe9d35f6c6db4d5088), [コメント②](https://trello.com/c/U9CH7xIK/293-%E3%82%AA%E3%82%A6%E3%83%B3%E3%83%89%E3%83%A1%E3%83%87%E3%82%A3%E3%82%A2%E6%A4%9C%E7%B4%A2%E5%88%86%E6%9E%90%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E5%87%BA%E5%8A%9B%E5%BD%A2%E5%BC%8F%E3%82%92%E5%A4%89%E6%9B%B4%E3%81%99%E3%82%8B#comment-63e1b668b3d0b9d7c608994e)