### PR TITLE
キーワードを除きページのみでグルーピング

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ const getDataFromSearchConsole = (keyword: string, startDate: Date, endDate: Dat
     const payload = {
         startDate: format(startDate, "yyyy-MM-dd"),
         endDate: format(endDate, "yyyy-MM-dd"),
-        dimensions: ["query", "page"],
+        dimensions: ["page"],
         rowLimit: maxRow, //取得するキーワードの最大数
         dimensionFilterGroups: [
             {
@@ -157,8 +157,8 @@ const getResponseGroupedByPageAttribute = (
 
     const searchPerformances: SearchPerformanceGroupedByQueryAndPage[] = response["rows"].map(({ keys, ...rest }) => {
         return {
-            query: keys[0],
-            page: keys[1],
+            query: keywordUrl.keyword,
+            page: keys[0],
             ...rest,
         };
     });


### PR DESCRIPTION
正規表現による表記揺れ (単語間のスペースの有無など) が別クエリとして出力されてしまう問題があった (ex.   「社債 購入」と「社債購入」が別クエリとしてスプレッドシートに出力)。
そのため、APIからのresponse形式を、キーワード、ページのグルーピングからページのみのグルーピングへと変更した。

[参考Trello](https://trello.com/c/3GnBr9eS)